### PR TITLE
Hotfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shiny2docker
 Title: Generate Dockerfiles for 'Shiny' Applications
-Version: 0.0.1
+Version: 0.0.1.0001
 Authors@R: 
     person("Vincent", "Guyader",
            email = "vincent@thinkr.fr",

--- a/inst/gitlab-ci.yml
+++ b/inst/gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
 build_shiny_image:
   stage: build
   image:
-    name: gcr.io/kaniko-project/executor
+    name: gcr.io/kaniko-project/executor:debug
     entrypoint: [""]
   script:
     - mkdir -p /kaniko/.docker


### PR DESCRIPTION
gcr.io/kaniko-project/executor:latest doesnt allow sh, we switch to gcr.io/kaniko-project/executor:debug