### PR TITLE
Fix GitHub capitalization in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## New functions
 
 + **`set_github_action`**  
-  Configure a Github Action pipeline for Docker builds.
+  Configure a GitHub Action pipeline for Docker builds.
 
 # shiny2docker 0.0.1
 


### PR DESCRIPTION
## Summary
- fix GitHub capitalization in NEWS.md

## Testing
- `R -q -e 'devtools::test()'` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e18f3d0c8328ac6003dec3a0c4b7