### PR TITLE
Fix default string in docs

### DIFF
--- a/R/shiny2docker.R
+++ b/R/shiny2docker.R
@@ -8,7 +8,7 @@
 #' @param lockfile Character. Path to the `renv.lock` file that specifies the R package dependencies. If the `renv.lock` file does not exist, it will be created for production using the `attachment::create_renv_for_prod` function.
 #' @param output Character. Path to the generated Dockerfile. Defaults to `"Dockerfile"`.
 #' @param FROM Docker image to start FROM Default is FROM rocker/r-base
-#' @param AS The AS of the Dockerfile. Default it `NULL`.
+#' @param AS The AS of the Dockerfile. Default is `NULL`.
 #' @param sysreqs boolean. If `TRUE`, the Dockerfile will contain sysreq installation.
 #' @param expand boolean. If `TRUE` each system requirement will have its own `RUN` line.
 #' @param repos character. The URL(s) of the repositories to use for `options("repos")`.

--- a/man/shiny2docker.Rd
+++ b/man/shiny2docker.Rd
@@ -30,7 +30,7 @@ shiny2docker(
 
 \item{FROM}{Docker image to start FROM Default is FROM rocker/r-base}
 
-\item{AS}{The AS of the Dockerfile. Default it \code{NULL}.}
+\item{AS}{The AS of the Dockerfile. Default is \code{NULL}.}
 
 \item{sysreqs}{boolean. If \code{TRUE}, the Dockerfile will contain sysreq installation.}
 


### PR DESCRIPTION
## Summary
- fix typo in `shiny2docker` parameter docs
- update manual page

## Testing
- `devtools::test()` *(fails: packages 'attachment', 'dockerfiler', and 'yesno' missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1822cc08328873b24e2502c074f