### PR TITLE
Add runner tag option for GitLab CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shiny2docker
 Title: Generate Dockerfiles for 'Shiny' Applications
-Version: 0.0.2
+Version: 0.0.2.9000
 Authors@R: 
     person("Vincent", "Guyader",
            email = "vincent@thinkr.fr",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+
+# shiny2docker dev version
+
+* `set_gitlab_ci()` now accepts a `tags` parameter so you can specify one or
+  more GitLab runner tags to use for the CI job.
+
 # shiny2docker 0.0.2
 
 ## New functions

--- a/R/set_gitlab_ci.R
+++ b/R/set_gitlab_ci.R
@@ -76,6 +76,7 @@ set_gitlab_ci <- function(path, tags = NULL) {
       writeLines(yaml_lines, dest_file)
     } else {
       cli::cli_alert_danger("Unable to locate stage line in .gitlab-ci.yml for tag insertion")
+      success <- FALSE
     }
   }
 

--- a/R/set_gitlab_ci.R
+++ b/R/set_gitlab_ci.R
@@ -43,7 +43,7 @@ set_gitlab_ci <- function(path, tags = NULL) {
       stop("Directory creation failed. Please check the path and permissions.")
     }
     cli::cli_alert_success("Directory created: {path}")
-  } 
+  }
 
   cli::cli_alert_info("Copying .gitlab-ci.yml file to: {path}")
 

--- a/R/set_gitlab_ci.R
+++ b/R/set_gitlab_ci.R
@@ -5,8 +5,11 @@
 #' and push the created image to the GitLab container registry.
 #'
 #' @param path A character string specifying the directory where the
-#' `.gitlab-ci.yml` file will be copied. If missing, the user will be prompted to use
-#' the current directory.
+#'   `.gitlab-ci.yml` file will be copied. If missing, the user will be prompted to use
+#'   the current directory.
+#' @param tags Optional character vector of GitLab runner tags. If provided, the
+#'   function will add these tags to the generated CI job so the appropriate
+#'   runner is selected. You can provide multiple tags.
 #'
 #' @return A logical value indicating whether the file was successfully copied (`TRUE`)
 #' or not (`FALSE`).
@@ -16,7 +19,10 @@
 #' @examples
 #' # Copy the .gitlab-ci.yml file to a temporary directory
 #' set_gitlab_ci(path = tempdir())
-set_gitlab_ci <- function(path) {
+#'
+#' # Copy the file and specify runner tags
+#' set_gitlab_ci(path = tempdir(), tags = c("shiny_build", "prod"))
+set_gitlab_ci <- function(path, tags = NULL) {
 
   # Check if the 'path' parameter is provided
   if (missing(path)) {
@@ -49,12 +55,29 @@ set_gitlab_ci <- function(path) {
   }
   cli::cli_alert_info("Found source file at: {source_file}")
 
+  # Path to destination file
+  dest_file <- file.path(path, ".gitlab-ci.yml")
+
   # Copy the gitlab-ci.yml file to the destination directory
   success <- file.copy(
     from = source_file,
-    to = file.path(path, ".gitlab-ci.yml"),
+    to = dest_file,
     overwrite = TRUE
   )
+
+  # If copy succeeded and tags supplied, add them to the job
+  if (isTRUE(success) && !is.null(tags)) {
+    cli::cli_alert_info("Adding runner tags to .gitlab-ci.yml: {paste(tags, collapse = ', ')}")
+    yaml_lines <- readLines(dest_file)
+    stage_line <- grep("^\\s*stage:", yaml_lines)[1]
+    if (length(stage_line) == 1 && !is.na(stage_line)) {
+      tag_lines <- c("  tags:", paste0("    - ", tags))
+      yaml_lines <- append(yaml_lines, tag_lines, after = stage_line)
+      writeLines(yaml_lines, dest_file)
+    } else {
+      cli::cli_alert_danger("Unable to locate stage line in .gitlab-ci.yml for tag insertion")
+    }
+  }
 
   if (isTRUE(success)) {
     cli::cli_alert_success(".gitlab-ci.yml file successfully copied to {path}")

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,6 +87,9 @@ library(shiny2docker)
 
 # Copy the .gitlab-ci.yml file to the current directory
 set_gitlab_ci()
+
+# Specify runner tags
+set_gitlab_ci(tags = c("shiny_build", "prod"))
 ```
 
 ### Configure GitHub Actions for Docker Builds

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ library(shiny2docker)
 
 # Copy the .gitlab-ci.yml file to the current directory
 set_gitlab_ci()
+
+# Specify runner tags
+set_gitlab_ci(tags = c("shiny_build", "prod"))
 ```
 
 ### Configure GitHub Actions for Docker Builds

--- a/man/set_gitlab_ci.Rd
+++ b/man/set_gitlab_ci.Rd
@@ -4,12 +4,14 @@
 \alias{set_gitlab_ci}
 \title{Configure GitLab CI pipeline for Docker builds}
 \usage{
-set_gitlab_ci(path)
+set_gitlab_ci(path, tags = NULL)
 }
 \arguments{
 \item{path}{A character string specifying the directory where the
 \code{.gitlab-ci.yml} file will be copied. If missing, the user will be prompted to use
 the current directory.}
+\item{tags}{Optional character vector of GitLab runner tags. If provided, these
+tags will be added to the CI job to select the appropriate runner. Multiple tags are allowed.}
 }
 \value{
 A logical value indicating whether the file was successfully copied (\code{TRUE})
@@ -23,4 +25,7 @@ and push the created image to the GitLab container registry.
 \examples{
 # Copy the .gitlab-ci.yml file to a temporary directory
 set_gitlab_ci(path = tempdir())
+
+# Copy the file and specify runner tags
+set_gitlab_ci(path = tempdir(), tags = c("shiny_build", "prod"))
 }

--- a/man/set_gitlab_ci.Rd
+++ b/man/set_gitlab_ci.Rd
@@ -10,8 +10,10 @@ set_gitlab_ci(path, tags = NULL)
 \item{path}{A character string specifying the directory where the
 \code{.gitlab-ci.yml} file will be copied. If missing, the user will be prompted to use
 the current directory.}
-\item{tags}{Optional character vector of GitLab runner tags. If provided, these
-tags will be added to the CI job to select the appropriate runner. Multiple tags are allowed.}
+
+\item{tags}{Optional character vector of GitLab runner tags. If provided, the
+function will add these tags to the generated CI job so the appropriate
+runner is selected. You can provide multiple tags.}
 }
 \value{
 A logical value indicating whether the file was successfully copied (\code{TRUE})

--- a/shiny2docker.Rproj
+++ b/shiny2docker.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 77ecc2cf-a94d-4ad3-a353-68d0edad10ea
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/test_tags.R
+++ b/test_tags.R
@@ -1,0 +1,31 @@
+# Test de la fonction set_gitlab_ci avec et sans tags
+
+# Charger la fonction
+source("R/set_gitlab_ci.R")
+
+# Test 1: Sans tags
+cat("=== Test 1: Sans tags ===\n")
+temp_dir1 <- tempdir()
+result1 <- set_gitlab_ci(path = temp_dir1)
+cat("Résultat:", result1, "\n")
+
+# Afficher le contenu généré
+cat("\nContenu généré (sans tags):\n")
+content1 <- readLines(file.path(temp_dir1, ".gitlab-ci.yml"))
+cat(content1, sep = "\n")
+
+cat("\n\n=== Test 2: Avec tags ===\n")
+# Test 2: Avec tags
+temp_dir2 <- file.path(tempdir(), "test_with_tags")
+dir.create(temp_dir2, showWarnings = FALSE)
+result2 <- set_gitlab_ci(path = temp_dir2, tags = c("docker", "linux"))
+cat("Résultat:", result2, "\n")
+
+# Afficher le contenu généré
+cat("\nContenu généré (avec tags):\n")
+content2 <- readLines(file.path(temp_dir2, ".gitlab-ci.yml"))
+cat(content2, sep = "\n")
+
+# Vérifier que les tags sont présents
+has_tags <- any(grepl("tags:", content2))
+cat("\nTags détectés dans le fichier:", has_tags, "\n")

--- a/tests/testthat/test-set_gitlab_ci.R
+++ b/tests/testthat/test-set_gitlab_ci.R
@@ -1,7 +1,7 @@
 library(testthat)
 
 # Create temp directory for testing
-tmp_dir <- tempdir(check = TRUE)
+tmp_dir <- tempfile()
 
 test_that("set_gitlab_ci inserts multiple tags", {
   set_gitlab_ci(path = tmp_dir, tags = c("shiny_build", "prod"))

--- a/tests/testthat/test-set_gitlab_ci.R
+++ b/tests/testthat/test-set_gitlab_ci.R
@@ -1,0 +1,15 @@
+library(testthat)
+
+# Create temp directory for testing
+tmp_dir <- tempdir(check = TRUE)
+
+test_that("set_gitlab_ci inserts multiple tags", {
+  file.remove(file.path(tmp_dir, ".gitlab-ci.yml"))
+  set_gitlab_ci(path = tmp_dir, tags = c("shiny_build", "prod"))
+  expect_true(file.exists(file.path(tmp_dir, ".gitlab-ci.yml")))
+  ci_lines <- readLines(file.path(tmp_dir, ".gitlab-ci.yml"))
+  expect_true(any(grepl("^\s*tags:\s*$", ci_lines)))
+  expect_true(any(grepl("shiny_build", ci_lines)))
+  expect_true(any(grepl("prod", ci_lines)))
+  file.remove(file.path(tmp_dir, ".gitlab-ci.yml"))
+})

--- a/tests/testthat/test-set_gitlab_ci.R
+++ b/tests/testthat/test-set_gitlab_ci.R
@@ -4,15 +4,11 @@ library(testthat)
 tmp_dir <- tempdir(check = TRUE)
 
 test_that("set_gitlab_ci inserts multiple tags", {
-  file.remove(file.path(tmp_dir, ".gitlab-ci.yml"))
   set_gitlab_ci(path = tmp_dir, tags = c("shiny_build", "prod"))
   expect_true(file.exists(file.path(tmp_dir, ".gitlab-ci.yml")))
   ci_lines <- readLines(file.path(tmp_dir, ".gitlab-ci.yml"))
-<<<<<<< HEAD
   expect_true(any(grepl("^\\s*tags:\\s*$", ci_lines)))
-=======
-  expect_true(any(grepl("^\s*tags:\s*$", ci_lines)))
->>>>>>> 430925e (Allow multiple runner tags in GitLab CI)
+  expect_true(any(grepl("^\\s*tags:\\s*$", ci_lines)))
   expect_true(any(grepl("shiny_build", ci_lines)))
   expect_true(any(grepl("prod", ci_lines)))
   file.remove(file.path(tmp_dir, ".gitlab-ci.yml"))

--- a/tests/testthat/test-set_gitlab_ci.R
+++ b/tests/testthat/test-set_gitlab_ci.R
@@ -8,7 +8,11 @@ test_that("set_gitlab_ci inserts multiple tags", {
   set_gitlab_ci(path = tmp_dir, tags = c("shiny_build", "prod"))
   expect_true(file.exists(file.path(tmp_dir, ".gitlab-ci.yml")))
   ci_lines <- readLines(file.path(tmp_dir, ".gitlab-ci.yml"))
+<<<<<<< HEAD
   expect_true(any(grepl("^\\s*tags:\\s*$", ci_lines)))
+=======
+  expect_true(any(grepl("^\s*tags:\s*$", ci_lines)))
+>>>>>>> 430925e (Allow multiple runner tags in GitLab CI)
   expect_true(any(grepl("shiny_build", ci_lines)))
   expect_true(any(grepl("prod", ci_lines)))
   file.remove(file.path(tmp_dir, ".gitlab-ci.yml"))

--- a/tests/testthat/test-set_gitlab_ci.R
+++ b/tests/testthat/test-set_gitlab_ci.R
@@ -8,7 +8,7 @@ test_that("set_gitlab_ci inserts multiple tags", {
   set_gitlab_ci(path = tmp_dir, tags = c("shiny_build", "prod"))
   expect_true(file.exists(file.path(tmp_dir, ".gitlab-ci.yml")))
   ci_lines <- readLines(file.path(tmp_dir, ".gitlab-ci.yml"))
-  expect_true(any(grepl("^\s*tags:\s*$", ci_lines)))
+  expect_true(any(grepl("^\\s*tags:\\s*$", ci_lines)))
   expect_true(any(grepl("shiny_build", ci_lines)))
   expect_true(any(grepl("prod", ci_lines)))
   file.remove(file.path(tmp_dir, ".gitlab-ci.yml"))

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -78,6 +78,9 @@ The package provides the `set_gitlab_ci()` function to simplify the process of c
 ```{r gitlab-ci, eval=FALSE}
 # Copy the .gitlab-ci.yml file to the current directory
 set_gitlab_ci(path = ".")
+
+# Specify runner tags
+set_gitlab_ci(path = ".", tags = c("shiny_build", "prod"))
 ```
 
 Once the `.gitlab-ci.yml` file is in place, you can integrate it with GitLab CI/CD to automate your Docker image build and deployment process.


### PR DESCRIPTION
## Summary
- document using `shiny_build` as the runner tag for `set_gitlab_ci`
- move NEWS entry to a new *dev version*
- add unit test ensuring runner tags are inserted
- allow specifying multiple tags in examples and docs

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: Rscript not found)*
- `Rscript -e 'devtools::document()'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e20b70648328a442b1ada3f8ff01