### PR TITLE
fix(dockerignore): exclude .Rprofile from the build context

### DIFF
--- a/R/shiny2docker.R
+++ b/R/shiny2docker.R
@@ -121,7 +121,8 @@ create_dockerignore <- function(path = ".dockerignore") {
                             ".gitignore",
                             "manifest.json",
                             "rsconnect/",
-                            ".Rproj.user")
+                            ".Rproj.user",
+                            ".Rprofile")
 
   writeLines(dockerignore_content, con = path)
 


### PR DESCRIPTION
## Summary

Adds `.Rprofile` to the list of paths written to `.dockerignore` by
`create_dockerignore()` (used by `shiny2docker()`).

## Why

`.Rprofile` is a per-project R startup file. In a typical dev setup it
contains things like `renv::activate()`, dev-only options, and paths
that point to the developer's machine. Copying it into a production
container changes the R startup behaviour silently — for instance, it
can override `.libPaths()` and shadow the library that `renv::restore()`
or `uvr sync` just populated, leading to packages being loaded from a
non-existent host path inside the image.

Excluding it matches the spirit of the existing entries (`.Rproj.user`,
`manifest.json`, `rsconnect/`) and aligns with what the experimental
uvr backend (`shiny2docker_uvr()`) already does in its variant of
`.dockerignore`.

## Scope

- Single line added in `R/shiny2docker.R` (`create_dockerignore`).
- No public API change. No documentation change required.
- Existing test only asserts that `.dockerignore` is created, not its
  content; no test update needed.

## Test plan

- [ ] `Rscript -e 'devtools::test()'` — existing tests still pass.
- [ ] Manual: run `shiny2docker()` on a project that has a `.Rprofile`,
      confirm the file is no longer copied into the image
      (`docker build --no-cache .` then `docker run --rm <img> ls -la /srv/shiny-server/.Rprofile`
      should report absent).