### PR TITLE
chore(pkgdown): wire GH Actions deploy to gh-pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,6 @@
 ^CRAN-SUBMISSION$
 ^doc$
 ^Meta$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,44 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 inst/doc
 /doc/
 /Meta/
+/docs/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://vincentguyader.github.io/shiny2docker/
+
+template:
+  bootstrap: 5


### PR DESCRIPTION
## Summary

Sets up pkgdown site generation and automated deployment to GitHub Pages via GitHub Actions.

## Changes

- **`_pkgdown.yml`** (new): site URL `https://vincentguyader.github.io/shiny2docker/`, Bootstrap 5 template.
- **`.github/workflows/pkgdown.yaml`** (new): standard r-lib/actions setup; runs on push to `main`, on PRs (build only), on release, and on manual dispatch. Uses `pkgdown::build_site_github_pages()` then `JamesIves/github-pages-deploy-action@v4.5.0` to push to the `gh-pages` branch (deploy step skipped on PRs).
- **`.Rbuildignore`**: exclude `_pkgdown.yml`, `docs/`, `pkgdown/` from the package tarball.
- **`.gitignore`**: exclude `/docs/` (site is deployed via Action, not committed to main).

## After merge

Enable GitHub Pages in repo Settings -> Pages:
- Source: **Deploy from a branch**
- Branch: **gh-pages**
- Folder: **/ (root)**

The first push to main after merge triggers the workflow, creates the `gh-pages` branch, and publishes the site.

## Local validation

- [x] `pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)` -> clean build, no URL warning, 12 pages + `.nojekyll`.
- [ ] CI on this PR will exercise the build step (deploy step is skipped on PRs).

## Test plan

- [x] Site builds locally with the same command the workflow uses.
- [ ] After merge: first run on main creates `gh-pages` branch.
- [ ] After GitHub Pages enablement: site reachable at the URL declared in `_pkgdown.yml`.